### PR TITLE
Changed eFP and rFP for ammo weapons

### DIFF
--- a/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
@@ -149,8 +149,8 @@ public class ItemStatsWeapon extends ItemStats {
         final int mwoId = Integer.parseInt(id);
         final int slots = WeaponStats.slots;
         final int roundsPerShot = WeaponStats.numFiring;
-        final int volleySize = WeaponStats.volleysize > 0 ? WeaponStats.volleysize : WeaponStats.numFiring;
         final int projectilesPerRound = WeaponStats.numPerShot > 0 ? WeaponStats.numPerShot : 1;
+        final int volleySize = WeaponStats.volleysize > 0 ? WeaponStats.volleysize : roundsPerShot;
         final double damagePerProjectile = determineDamage();
         final double cooldownValue = determineCooldown();
         final double mass = WeaponStats.tons;
@@ -202,7 +202,7 @@ public class ItemStatsWeapon extends ItemStats {
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot);
+                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot);
             case BALLISTIC:
                 final Attribute jamChanceAttrib = new Attribute(WeaponStats.JammingChance, selectors,
                                                                 ModifierDescription.SPEC_WEAPON_JAM_PROBABILITY);
@@ -217,11 +217,11 @@ public class ItemStatsWeapon extends ItemStats {
                         // HeatSource Arguments
                         heat,
                         // Weapon Arguments
-                        cooldown, rangeProfile, roundsPerShot, damagePerProjectile, projectilesPerRound,
+                        cooldown, rangeProfile, roundsPerShot, damagePerProjectile, projectilesPerRound, 
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot,
+                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot,
                         // BallisticWeapon Arguments
                         jamChanceAttrib, jamTimeAttrib, WeaponStats.ShotsDuringCooldown, WeaponStats.chargeTime,
                         WeaponStats.rampUpTime, WeaponStats.rampDownTime, WeaponStats.RampDownDelay,
@@ -260,7 +260,7 @@ public class ItemStatsWeapon extends ItemStats {
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot,
+                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot, 
                         // MissileWeapon Arguments
                         requiredGuidance, baseItemId);
             case ECM: // Fall through, not a weapon

--- a/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
@@ -112,6 +112,8 @@ public class ItemStatsWeapon extends ItemStats {
          */
         @XStreamAsAttribute
         public int numFiring;
+        @XStreamAsAttribute
+        public int volleysize;
         /**
          * The number of projectile in one round of ammo. Fired simultaneously (only LB type AC).
          */
@@ -147,6 +149,7 @@ public class ItemStatsWeapon extends ItemStats {
         final int mwoId = Integer.parseInt(id);
         final int slots = WeaponStats.slots;
         final int roundsPerShot = WeaponStats.numFiring;
+        final int volleySize = WeaponStats.volleysize > 0 ? WeaponStats.volleysize : WeaponStats.numFiring;
         final int projectilesPerRound = WeaponStats.numPerShot > 0 ? WeaponStats.numPerShot : 1;
         final double damagePerProjectile = determineDamage();
         final double cooldownValue = determineCooldown();
@@ -195,7 +198,7 @@ public class ItemStatsWeapon extends ItemStats {
                         // HeatSource Arguments
                         heat,
                         // Weapon Arguments
-                        cooldown, rangeProfile, roundsPerShot, damagePerProjectile, projectilesPerRound,
+                        cooldown, rangeProfile, roundsPerShot, volleySize, damagePerProjectile, projectilesPerRound,
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
@@ -253,7 +256,7 @@ public class ItemStatsWeapon extends ItemStats {
                         // HeatSource Arguments
                         heat,
                         // Weapon Arguments
-                        cooldown, rangeProfile, roundsPerShot, damagePerProjectile, projectilesPerRound,
+                        cooldown, rangeProfile, roundsPerShot, volleySize, damagePerProjectile, projectilesPerRound,
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments

--- a/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/database/gamedata/helpers/ItemStatsWeapon.java
@@ -75,6 +75,7 @@ public class ItemStatsWeapon extends ItemStats {
         public double RampDownDelay;
         @XStreamAsAttribute
         public int ShotsDuringCooldown;
+        // although ammoPerShot has an equvalent attribute in PGI files, numFiring is really how the ammo tracks.
         @XStreamAsAttribute
         public int ammoPerShot;
         @XStreamAsAttribute
@@ -202,7 +203,7 @@ public class ItemStatsWeapon extends ItemStats {
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot);
+                        getAmmoType(), isOneShot, roundsPerShot);
             case BALLISTIC:
                 final Attribute jamChanceAttrib = new Attribute(WeaponStats.JammingChance, selectors,
                                                                 ModifierDescription.SPEC_WEAPON_JAM_PROBABILITY);
@@ -221,7 +222,7 @@ public class ItemStatsWeapon extends ItemStats {
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot,
+                        getAmmoType(), isOneShot, roundsPerShot,
                         // BallisticWeapon Arguments
                         jamChanceAttrib, jamTimeAttrib, WeaponStats.ShotsDuringCooldown, WeaponStats.chargeTime,
                         WeaponStats.rampUpTime, WeaponStats.rampDownTime, WeaponStats.RampDownDelay,
@@ -260,7 +261,7 @@ public class ItemStatsWeapon extends ItemStats {
                         projectileSpeed, ghostHeatGroupId, ghostHeatMultiplier, ghostHeatFreeAlpha,
                         WeaponStats.volleydelay, WeaponStats.impulse,
                         // AmmoWeapon Arguments
-                        getAmmoType(), isOneShot, WeaponStats.ammoPerShot, 
+                        getAmmoType(), isOneShot, roundsPerShot, 
                         // MissileWeapon Arguments
                         requiredGuidance, baseItemId);
             case ECM: // Fall through, not a weapon

--- a/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
@@ -49,7 +49,9 @@ public class AmmoWeapon extends Weapon {
     @XStreamAsAttribute
     private final int ammoPerShot;
     @XStreamAsAttribute
-    private final boolean oneShot;
+    private final boolean oneShot;    
+    @XStreamAsAttribute
+    private final double firingDelay;
     
     public AmmoWeapon(
             // Item Arguments
@@ -62,20 +64,17 @@ public class AmmoWeapon extends Weapon {
             int aProjectilesPerRound, Attribute aProjectileSpeed, int aGhostHeatGroupId, double aGhostHeatMultiplier,
             Attribute aGhostHeatMaxFreeAlpha, double aVolleyDelay, double aImpulse,
             // AmmoWeapon Arguments
-            String aAmmoType, boolean aOneShot) {
+            String aAmmoType, boolean aOneShot, int aAmmoPerShot) {
         super(aName, aDesc, aMwoName, aMwoId, aSlots, aTons, aHardPointType, aHP, aFaction, aHeat, aCoolDown,
               aRangeProfile, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
         ammoTypeId = aAmmoType;
-        // protect from bad values
-        if (aVolleySize < 1) { 
-            volleySize = aRoundsPerShot; 
-        } else { 
-            volleySize = aVolleySize; 
-        }
-        // I find no instance in PGI files of ammoPerShot being different from numFiring in AmmoWeapons, so not reading this from the file, yet.   
-        ammoPerShot = aRoundsPerShot;
+        volleySize = aVolleySize;  
+        ammoPerShot = aAmmoPerShot;
         oneShot = aOneShot;
+                
+        double numVolleys = Math.ceil((double) aRoundsPerShot / (double) aVolleySize); 
+        firingDelay = (numVolleys - 1) * aVolleyDelay;
     }
 
     public Ammunition getAmmoHalfType() {
@@ -110,6 +109,10 @@ public class AmmoWeapon extends Weapon {
         return isOneShot() ? Double.POSITIVE_INFINITY : super.getCoolDown(aModifiers);
     }
 
+    public double getFiringDelay() {
+        return firingDelay;
+    }
+    
     /**
     * {@inheritDoc}
     *
@@ -121,11 +124,7 @@ public class AmmoWeapon extends Weapon {
 
     @Override
     public double getRawFiringPeriod(Collection<Modifier> aModifiers) {
-        double numRoundsPerShot = (double) super.getRoundsPerShot();
-        double tempVolleySize = (double) volleySize;
-
-        double numVolleys = Math.ceil(numRoundsPerShot / tempVolleySize); 
-        double firingDelay = (numVolleys - 1) * super.getVolleyDelay();
+        double firingDelay = getFiringDelay();
         double cooldown = getCoolDown(aModifiers); 
 
         return isOneShot() ? Double.POSITIVE_INFINITY : firingDelay + cooldown;

--- a/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
@@ -45,7 +45,7 @@ public class AmmoWeapon extends Weapon {
     @XStreamAsAttribute
     private final String ammoTypeId;
     @XStreamAsAttribute
-    private final int volleysize;
+    private final int volleySize;
     @XStreamAsAttribute
     private final int ammoPerShot;
     @XStreamAsAttribute
@@ -68,7 +68,11 @@ public class AmmoWeapon extends Weapon {
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
         ammoTypeId = aAmmoType;
         // protect from bad values
-        if (aVolleySize < 1) { volleysize = aRoundsPerShot; } else { volleysize = aVolleySize; }
+        if (aVolleySize < 1) { 
+            volleySize = aRoundsPerShot; 
+        } else { 
+            volleySize = aVolleySize; 
+        }
         // I find no instance in PGI files of ammoPerShot being different from numFiring in AmmoWeapons, so not reading this from the file, yet.   
         ammoPerShot = aRoundsPerShot;
         oneShot = aOneShot;
@@ -90,7 +94,7 @@ public class AmmoWeapon extends Weapon {
     }
 
     public int getVolleySize() {
-        return volleysize;
+        return volleySize;
     }
     
     public int getAmmoPerShot() {
@@ -106,26 +110,21 @@ public class AmmoWeapon extends Weapon {
         return isOneShot() ? Double.POSITIVE_INFINITY : super.getCoolDown(aModifiers);
     }
 
-     /**
-     * The unmodified time between shots. C.f. {@link #getExpectedFiringPeriod(Collection)}.
-     * <p>
-     * Note that this is different from cooldown which is the time the weapon is unavailable between uses, this is
-     * the time between activations of the weapon. In particular this includes the time that it takes to charge
-     * a gauss rifle, the burn time of lasers, the volley delay from LRMs etc that is not included in cooldown.
-     *
-     * @return The firing period [seconds]
-     * @param aModifiers The modifiers to apply from quirks etc.
-     * there can also be additional delay for hardpoint volley size limitations. not accounted for, yet.
-     */
+    /**
+    * {@inheritDoc}
+    *
+    * Also accounts for volley size of weapons that have such limitations.
+    * 
+    * @param aModifiers {@inheritDoc}
+    * @return {@inheritDoc}
+    **/
+
     @Override
     public double getRawFiringPeriod(Collection<Modifier> aModifiers) {
-        int numRoundsPerShot = super.getRoundsPerShot();
-        int volleySize = volleysize;
-        if (volleySize < 1) {
-            // This is just to fix this if someting went wrong.  probably should through an exception of some sort.
-            volleySize = numRoundsPerShot;
-        }
-        double numVolleys = Math.ceil(numRoundsPerShot / volleySize); 
+        double numRoundsPerShot = (double) super.getRoundsPerShot();
+        double tempVolleySize = (double) volleySize;
+
+        double numVolleys = Math.ceil(numRoundsPerShot / tempVolleySize); 
         double firingDelay = (numVolleys - 1) * super.getVolleyDelay();
         double cooldown = getCoolDown(aModifiers); 
 

--- a/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
@@ -51,7 +51,7 @@ public class AmmoWeapon extends Weapon {
     @XStreamAsAttribute
     private final boolean oneShot;    
     @XStreamAsAttribute
-    private final double firingDelay;
+    private final double volleyDelay;
     
     public AmmoWeapon(
             // Item Arguments
@@ -67,14 +67,12 @@ public class AmmoWeapon extends Weapon {
             String aAmmoType, boolean aOneShot, int aAmmoPerShot) {
         super(aName, aDesc, aMwoName, aMwoId, aSlots, aTons, aHardPointType, aHP, aFaction, aHeat, aCoolDown,
               aRangeProfile, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
-              aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
+              aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aImpulse);
         ammoTypeId = aAmmoType;
         volleySize = aVolleySize;  
+        volleyDelay = aVolleyDelay;
         ammoPerShot = aAmmoPerShot;
         oneShot = aOneShot;
-                
-        double numVolleys = Math.ceil((double) aRoundsPerShot / (double) aVolleySize); 
-        firingDelay = (numVolleys - 1) * aVolleyDelay;
     }
 
     public Ammunition getAmmoHalfType() {
@@ -96,6 +94,10 @@ public class AmmoWeapon extends Weapon {
         return volleySize;
     }
     
+    public double getVolleyDelay() {
+        return volleyDelay;
+    }
+    
     public int getAmmoPerShot() {
         return ammoPerShot;
     }
@@ -110,6 +112,8 @@ public class AmmoWeapon extends Weapon {
     }
 
     public double getFiringDelay() {
+        double numVolleys = Math.ceil((double) super.getRoundsPerShot() / (double) volleySize); 
+        double firingDelay = (numVolleys - 1) * volleyDelay;
         return firingDelay;
     }
     

--- a/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/AmmoWeapon.java
@@ -90,11 +90,11 @@ public class AmmoWeapon extends Weapon {
         return ammoType;
     }
 
-    public int getVolleySize() {
+    protected int getVolleySize() {
         return volleySize;
     }
     
-    public double getVolleyDelay() {
+    protected double getVolleyDelay() {
         return volleyDelay;
     }
     

--- a/src/main/java/org/lisoft/lsml/model/item/BallisticWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/BallisticWeapon.java
@@ -63,7 +63,7 @@ public class BallisticWeapon extends AmmoWeapon {
             int aProjectilesPerRound, Attribute aProjectileSpeed, int aGhostHeatGroupId, double aGhostHeatMultiplier,
             Attribute aGhostHeatMaxFreeAlpha, double aVolleyDelay, double aImpulse,
             // AmmoWeapon Arguments
-            String aAmmoType, boolean aOneShot,
+            String aAmmoType, boolean aOneShot, int aAmmoPerShot, 
             // Ballistic Arguments
             Attribute aJammingChance, Attribute aJammingTime, int aShotsDuringCooldown, double aChargeTime,
             double aRampUpTime, double aRampDownTime, double aRampDownDelay, double aJamRampUpTime,
@@ -72,11 +72,11 @@ public class BallisticWeapon extends AmmoWeapon {
               aName, aDesc, aMwoName, aMwoId, aSlots, aTons, HardPointType.BALLISTIC, aHP, aFaction,
               // HeatSource Arguments
               aHeat,
-              // Weapon Arguments
-              aCooldown, aRangeProfile, aRoundsPerShot, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
+              // Weapon Arguments, and volleySize is always set to one
+              aCooldown, aRangeProfile, aRoundsPerShot, 1, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse,
               // AmmoWeapon Arguments
-              aAmmoType, aOneShot);
+              aAmmoType, aOneShot, aAmmoPerShot);
         jammingChance = aJammingChance;
         jammingTime = aJammingTime;
         shotsDuringCooldown = aShotsDuringCooldown;

--- a/src/main/java/org/lisoft/lsml/model/item/BallisticWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/BallisticWeapon.java
@@ -73,7 +73,7 @@ public class BallisticWeapon extends AmmoWeapon {
               // HeatSource Arguments
               aHeat,
               // Weapon Arguments
-              aCooldown, aRangeProfile, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
+              aCooldown, aRangeProfile, aRoundsPerShot, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse,
               // AmmoWeapon Arguments
               aAmmoType, aOneShot);
@@ -90,6 +90,7 @@ public class BallisticWeapon extends AmmoWeapon {
     }
 
     public boolean canDoubleFire() {
+        // this is not the true definition for this value, and while currently only 1 for those that can fire mduring cooldown, that may not always be the case.
         return jammingChance.value(null) > 0.0;
     }
 
@@ -99,6 +100,7 @@ public class BallisticWeapon extends AmmoWeapon {
 
     @Override
     public double getExpectedFiringPeriod(Collection<Modifier> aModifiers) {
+        // candoublefire is used more like a canjam not candoublefire.  
         if (canDoubleFire()) {
             final double cd = getRawFiringPeriod(aModifiers);
             final double jamP = getJamProbability(aModifiers);

--- a/src/main/java/org/lisoft/lsml/model/item/EnergyWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/EnergyWeapon.java
@@ -51,7 +51,7 @@ public class EnergyWeapon extends Weapon {
               aHeat,
               // Weapon Arguments
               aCooldown, aRangeProfile, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
-              aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
+              aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aImpulse);
         burnTime = aBurnTime;
     }
 

--- a/src/main/java/org/lisoft/lsml/model/item/ItemComparator.java
+++ b/src/main/java/org/lisoft/lsml/model/item/ItemComparator.java
@@ -97,8 +97,8 @@ public class ItemComparator implements Comparator<Item>, Serializable {
                 final MissileWeapon weapon = (MissileWeapon) item;
                 final int rank = rankMissile(weapon);
                 ITEM_PRIORITY.put(weapon, new Pair<>(rank, rank));
-                if (!weapon.hasBuiltInAmmo() && (weapon.getAmmoPerPerShot() == 5 || weapon.getAmmoPerPerShot() == 2 ||
-                                                 weapon.getAmmoPerPerShot() == 1)) {
+                if (!weapon.hasBuiltInAmmo() && (weapon.getRoundsPerShot() == 5 || weapon.getRoundsPerShot() == 2 ||
+                                                 weapon.getRoundsPerShot() == 1)) {
                     ITEM_PRIORITY.put(weapon.getAmmoType(), new Pair<>(rank + 1, rank + 1));
                     ITEM_PRIORITY.put(weapon.getAmmoHalfType(), new Pair<>(rank + 2, rank + 2));
                 }
@@ -288,7 +288,7 @@ public class ItemComparator implements Comparator<Item>, Serializable {
         final int scoreArtemis = aItem.getName().contains("ARTEM") ? 1 : 0;
 
         final int score = RANK_MISSILE + scoreLRM + scoreMRM + scoreSRM + scoreRocket + scoreATM + scoreStreak +
-                          scoreNARC + scoreArtemis + (50 - aItem.getAmmoPerPerShot()) * 1000 + factionScore(aItem) * 10;
+                          scoreNARC + scoreArtemis + (50 - aItem.getRoundsPerShot()) * 1000 + factionScore(aItem) * 10;
 
         if (score >= RANK_MISSILE + CLASS_SCORE) {
             throw new RuntimeException("Missile weapon sorting rank overflow");

--- a/src/main/java/org/lisoft/lsml/model/item/MissileWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/MissileWeapon.java
@@ -43,7 +43,7 @@ public class MissileWeapon extends AmmoWeapon {
             // HeatSource Arguments
             Attribute aHeat,
             // Weapon Arguments
-            Attribute aCooldown, WeaponRangeProfile aRangeProfile, int aRoundsPerShot, double aDamagePerProjectile,
+            Attribute aCooldown, WeaponRangeProfile aRangeProfile, int aRoundsPerShot, int aVolleySize, double aDamagePerProjectile,
             int aProjectilesPerRound, Attribute aProjectileSpeed, int aGhostHeatGroupId, double aGhostHeatMultiplier,
             Attribute aGhostHeatMaxFreeAlpha, double aVolleyDelay, double aImpulse,
             // AmmoWeapon Arguments
@@ -55,7 +55,7 @@ public class MissileWeapon extends AmmoWeapon {
               // HeatSource Arguments
               aHeat,
               // Weapon Arguments
-              aCooldown, aRangeProfile, aRoundsPerShot, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
+              aCooldown, aRangeProfile, aRoundsPerShot, aVolleySize, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse,
               // AmmoWeapon Arguments
               aAmmoType, aOneShot);
@@ -67,16 +67,6 @@ public class MissileWeapon extends AmmoWeapon {
         return baseItemId;
     }
 
-    @Override
-    public double getExpectedFiringPeriod(Collection<Modifier> aModifiers) {
-        if (getFaction() == Faction.INNERSPHERE || getAliases().contains("srm") || getAliases().contains("streaksrm")) {
-            // Implicit assumption that:
-            // 1) All missiles can launch simultaneously for IS LRM launchers.
-            // 2) All missiles can launch simultaneously for IS + Clan (S)SRM launchers.
-            return getCoolDown(aModifiers);
-        }
-        return super.getExpectedFiringPeriod(aModifiers);
-    }
 
     @Override
     public double getMass() {

--- a/src/main/java/org/lisoft/lsml/model/item/MissileWeapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/MissileWeapon.java
@@ -47,7 +47,7 @@ public class MissileWeapon extends AmmoWeapon {
             int aProjectilesPerRound, Attribute aProjectileSpeed, int aGhostHeatGroupId, double aGhostHeatMultiplier,
             Attribute aGhostHeatMaxFreeAlpha, double aVolleyDelay, double aImpulse,
             // AmmoWeapon Arguments
-            String aAmmoType, boolean aOneShot,
+            String aAmmoType, boolean aOneShot, int aAmmoPerShot,
             // MissileWeapon Arguments
             int aRequiredGuidanceId, int aBaseItemId) {
         super(// Item Arguments
@@ -58,7 +58,7 @@ public class MissileWeapon extends AmmoWeapon {
               aCooldown, aRangeProfile, aRoundsPerShot, aVolleySize, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
               aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse,
               // AmmoWeapon Arguments
-              aAmmoType, aOneShot);
+              aAmmoType, aOneShot, aAmmoPerShot);
         requiredGuidanceID = aRequiredGuidanceId;
         baseItemId = aBaseItemId;
     }

--- a/src/main/java/org/lisoft/lsml/model/item/Weapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/Weapon.java
@@ -198,11 +198,10 @@ public class Weapon extends HeatSource {
      * the time between activations of the weapon. In particular this includes the time that it takes to charge
      * a gauss rifle, the burn time of lasers, the volley delay from LRMs etc that is not included in cooldown.
      * 
-     * ammoweapons and energy weaspons calculate this differently. So this is an overridden method.
+     * Ammo weapons and energy weapons calculate this differently. So this is an overridden method.
      *
      * @return The firing period [seconds]
      * @param aModifiers The modifiers to apply from quirks etc.
-     * there can also be additional delay for hardpoint volley size limitations. not accounted for, yet.
      */
     public double getRawFiringPeriod(Collection<Modifier> aModifiers) {
         double cooldown = getCoolDown(aModifiers); 

--- a/src/main/java/org/lisoft/lsml/model/item/Weapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/Weapon.java
@@ -61,12 +61,13 @@ public class Weapon extends HeatSource {
     private final int projectilesPerRound;
     private final WeaponRangeProfile rangeProfile;
     /**
-     * How many rounds of ammo per shot of the weapon.
+     * How many rounds and how fast are they fired per shot of the weapon.
      */
     @XStreamAsAttribute
     private final int roundsPerShot;
     @XStreamAsAttribute
     private final double volleyDelay;
+   
 
     public Weapon(
             // Item Arguments
@@ -104,8 +105,11 @@ public class Weapon extends HeatSource {
         return Collections.unmodifiableCollection(coolDown.getSelectors());
     }
 
-    public int getAmmoPerPerShot() {
+    public int getRoundsPerShot() {
         return roundsPerShot;
+    }
+    public double getVolleyDelay() {
+        return volleyDelay;
     }
 
     /**
@@ -129,7 +133,10 @@ public class Weapon extends HeatSource {
 
     /**
      * The statistically expected time between shots accounting for weapon jams and double fire etc.
-     *
+     * @param aModifiers The modifiers to apply from quirks etc.
+     * 
+     * this is overridden for the ballistic weapons that jam and double fire.
+     * 
      * @return The firing period [seconds]
      */
     public double getExpectedFiringPeriod(Collection<Modifier> aModifiers) {
@@ -190,11 +197,17 @@ public class Weapon extends HeatSource {
      * Note that this is different from cooldown which is the time the weapon is unavailable between uses, this is
      * the time between activations of the weapon. In particular this includes the time that it takes to charge
      * a gauss rifle, the burn time of lasers, the volley delay from LRMs etc that is not included in cooldown.
+     * 
+     * ammoweapons and energy weaspons calculate this differently. So this is an overridden method.
      *
      * @return The firing period [seconds]
+     * @param aModifiers The modifiers to apply from quirks etc.
+     * there can also be additional delay for hardpoint volley size limitations. not accounted for, yet.
      */
     public double getRawFiringPeriod(Collection<Modifier> aModifiers) {
-        return getCoolDown(aModifiers) + volleyDelay * (roundsPerShot - 1);
+        double cooldown = getCoolDown(aModifiers); 
+        
+        return cooldown;
     }
 
     /**

--- a/src/main/java/org/lisoft/lsml/model/item/Weapon.java
+++ b/src/main/java/org/lisoft/lsml/model/item/Weapon.java
@@ -65,8 +65,7 @@ public class Weapon extends HeatSource {
      */
     @XStreamAsAttribute
     private final int roundsPerShot;
-    @XStreamAsAttribute
-    private final double volleyDelay;
+
    
 
     public Weapon(
@@ -78,7 +77,7 @@ public class Weapon extends HeatSource {
             // Weapon Arguments
             Attribute aCoolDown, WeaponRangeProfile aRangeProfile, int aRoundsPerShot, double aDamagePerProjectile,
             int aProjectilesPerRound, Attribute aProjectileSpeed, int aGhostHeatGroupId, double aGhostHeatMultiplier,
-            Attribute aGhostHeatMaxFreeAlpha, double aVolleyDelay, double aImpulse) {
+            Attribute aGhostHeatMaxFreeAlpha, double aImpulse) {
         super(aName, aDesc, aMwoName, aMwoId, aSlots, aTons, aHardPointType, aHP, aFaction, null, null, aHeat);
         coolDown = aCoolDown;
         rangeProfile = aRangeProfile;
@@ -89,7 +88,6 @@ public class Weapon extends HeatSource {
         ghostHeatGroupId = aGhostHeatGroupId;
         ghostHeatMultiplier = aGhostHeatMultiplier;
         ghostHeatFreeAlpha = aGhostHeatMaxFreeAlpha;
-        volleyDelay = aVolleyDelay;
         impulse = aImpulse;
 
         if (roundsPerShot < 1) {
@@ -108,9 +106,7 @@ public class Weapon extends HeatSource {
     public int getRoundsPerShot() {
         return roundsPerShot;
     }
-    public double getVolleyDelay() {
-        return volleyDelay;
-    }
+
 
     /**
      * Gets the modified cooldown value as show in-game. For single shot weapons, this can be positive infinity. For

--- a/src/main/java/org/lisoft/lsml/view_fx/util/WeaponSummary.java
+++ b/src/main/java/org/lisoft/lsml/view_fx/util/WeaponSummary.java
@@ -108,7 +108,7 @@ public class WeaponSummary {
                 if (!weapons.isEmpty()) {
                     if (weapons.iterator().next() instanceof AmmoWeapon) {
                         return weapons.stream().map(w -> (AmmoWeapon) w)
-                                      .collect(Collectors.summingInt(AmmoWeapon::getAmmoPerPerShot));
+                                      .collect(Collectors.summingInt(AmmoWeapon::getRoundsPerShot));
                     }
                     return weapons.size();
                 }
@@ -151,7 +151,7 @@ public class WeaponSummary {
                 if (weapon.getDamagePerProjectile() == 0) {
                     return 0.0;
                 }
-                return ammoRounds.get() * weapon.getDamagePerShot() / weapon.getAmmoPerPerShot();
+                return ammoRounds.get() * weapon.getDamagePerShot() / weapon.getRoundsPerShot();
             }
         };
 
@@ -286,7 +286,7 @@ public class WeaponSummary {
     private boolean shouldCountTubes(Item aItem) {
         if (aItem instanceof MissileWeapon) {
             final MissileWeapon missileWeapon = (MissileWeapon) aItem;
-            return missileWeapon.getAmmoPerPerShot() > 1;
+            return missileWeapon.getRoundsPerShot() > 1;
         }
         return false;
     }

--- a/src/main/java/org/lisoft/lsml/view_fx/util/WeaponSummary.java
+++ b/src/main/java/org/lisoft/lsml/view_fx/util/WeaponSummary.java
@@ -151,7 +151,12 @@ public class WeaponSummary {
                 if (weapon.getDamagePerProjectile() == 0) {
                     return 0.0;
                 }
-                return ammoRounds.get() * weapon.getDamagePerShot() / weapon.getRoundsPerShot();
+                if (weapon instanceof AmmoWeapon) {
+                    AmmoWeapon ammoWeapon = (AmmoWeapon) weapon;
+                
+                    return ammoRounds.get() * ammoWeapon.getDamagePerShot() / ammoWeapon.getAmmoPerShot();
+                }
+                return Double.POSITIVE_INFINITY;
             }
         };
 

--- a/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
@@ -115,4 +115,17 @@ public class AmmoWeaponTest {
         assertEquals(1, clrm10.getVolleySize());
         assertEquals(1, ac20.getVolleySize());
     }
+    
+    @Test
+    public void testRawFiringPeriod() throws Exception {
+        final AmmoWeapon ac20 = (AmmoWeapon) ItemDB.lookup("AC/20");
+        final AmmoWeapon lrm10 = (AmmoWeapon) ItemDB.lookup("LRM 10");
+        final AmmoWeapon clrm10 = (AmmoWeapon) ItemDB.lookup("C-LRM 10");
+        final AmmoWeapon srm6 = (AmmoWeapon) ItemDB.lookup("SRM6");
+        
+        assertEquals(lrm10.getCoolDown(null), lrm10.getRawFiringPeriod(null),0.0);
+        assertEquals(0.05*9+clrm10.getCoolDown(null), clrm10.getRawFiringPeriod(null),0.0);
+        assertEquals(ac20.getCoolDown(null), ac20.getRawFiringPeriod(null),0.0);
+        assertEquals(srm6.getCoolDown(null), srm6.getRawFiringPeriod(null),0.0);
+    }
 }

--- a/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
@@ -59,7 +59,7 @@ public class AmmoWeaponTest {
     @Test
     public final void testIsCompatibleAmmoBuiltinAmmo() throws Exception {
         final AmmoWeapon builtInAmmo = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN,
-                                                      null, null, null, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null,
+                                                      null, null, null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null,
                                                       false);
         final Ammunition ac20ammo = new Ammunition("", "", "", 0, 0, 0.0, HardPointType.NONE, 0.0, Faction.CLAN, 10,
                                                    "ammotype", 0.0);
@@ -70,14 +70,14 @@ public class AmmoWeaponTest {
     @Test
     public final void testIsOneShotNegative() throws Exception {
         final AmmoWeapon cut = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN, null, null,
-                                              null, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, false);
+                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, false);
         assertFalse(cut.isOneShot());
     }
 
     @Test
     public final void testIsOneShotPositive() throws Exception {
         final AmmoWeapon cut = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN, null, null,
-                                              null, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, true);
+                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, true);
         assertTrue(cut.isOneShot());
     }
 
@@ -103,5 +103,16 @@ public class AmmoWeaponTest {
         final double quirked = cut.getRangeProfile().getSpread().value(Arrays.asList(modifier));
 
         assertEquals(normal * 2, quirked, 0.0);
+    }
+    
+    @Test
+    public void testGetVolleySize() throws Exception {
+        final AmmoWeapon ac20 = (AmmoWeapon) ItemDB.lookup("AC/20");
+        final AmmoWeapon lrm10 = (AmmoWeapon) ItemDB.lookup("LRM 10");
+        final AmmoWeapon clrm10 = (AmmoWeapon) ItemDB.lookup("C-LRM 10");
+        
+        assertEquals(10, lrm10.getVolleySize());
+        assertEquals(1, clrm10.getVolleySize());
+        assertEquals(1, ac20.getVolleySize());
     }
 }

--- a/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
@@ -112,9 +112,9 @@ public class AmmoWeaponTest {
         final AmmoWeapon clrm10 = (AmmoWeapon) ItemDB.lookup("C-LRM 10");
         final AmmoWeapon cuac10 = (AmmoWeapon) ItemDB.lookup("C-ULTRA AC/10");
         
-        assertEquals(10.0, lrm10.getVolleySize(),0.0);
-        assertEquals(1.0, clrm10.getVolleySize(),0.0);
-        assertEquals(1.0, ac20.getVolleySize(),0.0);
+        assertEquals(10, lrm10.getVolleySize());
+        assertEquals(1, clrm10.getVolleySize());
+        assertEquals(1, ac20.getVolleySize());
         assertEquals(1, cuac10.getVolleySize());
     }
     

--- a/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/AmmoWeaponTest.java
@@ -60,7 +60,7 @@ public class AmmoWeaponTest {
     public final void testIsCompatibleAmmoBuiltinAmmo() throws Exception {
         final AmmoWeapon builtInAmmo = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN,
                                                       null, null, null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null,
-                                                      false);
+                                                      false, 1);
         final Ammunition ac20ammo = new Ammunition("", "", "", 0, 0, 0.0, HardPointType.NONE, 0.0, Faction.CLAN, 10,
                                                    "ammotype", 0.0);
 
@@ -70,14 +70,14 @@ public class AmmoWeaponTest {
     @Test
     public final void testIsOneShotNegative() throws Exception {
         final AmmoWeapon cut = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN, null, null,
-                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, false);
+                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, false, 1);
         assertFalse(cut.isOneShot());
     }
 
     @Test
     public final void testIsOneShotPositive() throws Exception {
         final AmmoWeapon cut = new AmmoWeapon("", "", "", 0, 0, 0.0, HardPointType.ENERGY, 0, Faction.CLAN, null, null,
-                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, true);
+                                              null, 1, 1, 1, 1, null, 0, 0.0, null, 0.0, 0.0, null, true, 1);
         assertTrue(cut.isOneShot());
     }
 
@@ -110,10 +110,12 @@ public class AmmoWeaponTest {
         final AmmoWeapon ac20 = (AmmoWeapon) ItemDB.lookup("AC/20");
         final AmmoWeapon lrm10 = (AmmoWeapon) ItemDB.lookup("LRM 10");
         final AmmoWeapon clrm10 = (AmmoWeapon) ItemDB.lookup("C-LRM 10");
+        final AmmoWeapon cuac10 = (AmmoWeapon) ItemDB.lookup("C-ULTRA AC/10");
         
-        assertEquals(10, lrm10.getVolleySize());
-        assertEquals(1, clrm10.getVolleySize());
-        assertEquals(1, ac20.getVolleySize());
+        assertEquals(10.0, lrm10.getVolleySize(),0.0);
+        assertEquals(1.0, clrm10.getVolleySize(),0.0);
+        assertEquals(1.0, ac20.getVolleySize(),0.0);
+        assertEquals(1, cuac10.getVolleySize());
     }
     
     @Test

--- a/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
@@ -44,12 +44,29 @@ public class BallisticWeaponTest {
         assertTrue(cut.getName().contains("C-ULTRA AC/10"));
         assertEquals(3, cut.getRoundsPerShot());
         assertEquals(10.0, cut.getDamagePerShot(), 0.0003);
+        final double firingDelay = cut.getFiringDelay();
+        assertEquals(0.11*(3.0-1.0), firingDelay, 0.0);     
 
-        final double expectedSecondsPerShot = cut.getCoolDown(null); 
+        final double expectedSecondsPerShot = cut.getCoolDown(null) + firingDelay; 
 
         assertEquals(expectedSecondsPerShot, cut.getRawFiringPeriod(null), 0.0);
     }
 
+    public void testLBX10() throws Exception {
+        final BallisticWeapon cut = (BallisticWeapon) ItemDB.lookup(1206);
+
+        assertTrue(cut.getName().contains("LB-10X"));
+        assertEquals(1, cut.getRoundsPerShot());
+        assertEquals(10, cut.getProjectilesPerShot());
+        assertEquals(10.0, cut.getDamagePerShot(), 0.0003);
+        final double firingDelay = cut.getFiringDelay();
+        assertEquals(0.0, firingDelay, 0.0);     
+
+        final double expectedSecondsPerShot = cut.getCoolDown(null) + firingDelay; 
+
+        assertEquals(expectedSecondsPerShot, cut.getRawFiringPeriod(null), 0.0);
+    }
+    
     @Test
     public void testGaussChargeTime() throws Exception {
         final BallisticWeapon isGauss = (BallisticWeapon) ItemDB.lookup(1021);
@@ -160,10 +177,10 @@ public class BallisticWeaponTest {
         final BallisticWeapon cut = new BallisticWeapon("name", "desc", "mwoname", 0, 1, 1.0, 10.0, Faction.INNERSPHERE,
                                                         // Item
                                                         new Attribute(1, Collections.EMPTY_SET), // Heat
-                                                        aCooldown, null, 1, 1, 1,
+                                                        aCooldown, null, 1, 1, 1, 
                                                         new Attribute(1, Collections.EMPTY_SET), 0, 0,
                                                         new Attribute(1, Collections.EMPTY_SET), 0, 0, // Weapon
-                                                        "ammo", false, // Ammo
+                                                        "ammo", false, 1, // Ammo
                                                         aJammingChance, aJammingTime, 1, aChargeTime, aRampUpTime,
                                                         aRampDownTime, aRampDownDelay, aJamRampUpTime,
                                                         aJamRampDownTime);

--- a/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
@@ -42,10 +42,10 @@ public class BallisticWeaponTest {
         final BallisticWeapon cut = (BallisticWeapon) ItemDB.lookup(1206);
 
         assertTrue(cut.getName().contains("C-ULTRA AC/10"));
-        assertEquals(3, cut.getAmmoPerPerShot());
+        assertEquals(3, cut.getRoundsPerShot());
         assertEquals(10.0, cut.getDamagePerShot(), 0.0001);
 
-        final double expectedSecondsPerShot = cut.getCoolDown(null) + 0.11 * 2;
+        final double expectedSecondsPerShot = cut.getCoolDown(null); 
 
         assertEquals(expectedSecondsPerShot, cut.getRawFiringPeriod(null), 0.0);
     }
@@ -129,7 +129,7 @@ public class BallisticWeaponTest {
         final BallisticWeapon cut = (BallisticWeapon) ItemDB.lookup("LB 10-X AC");
 
         assertTrue(cut.getName().contains("LB 10-X AC"));
-        assertEquals(1, cut.getAmmoPerPerShot());
+        assertEquals(1, cut.getRoundsPerShot());
         assertTrue(cut.getDamagePerShot() > 5.0);
 
         final double expectedSecondsPerShot = cut.getCoolDown(null);
@@ -142,7 +142,7 @@ public class BallisticWeaponTest {
         final BallisticWeapon cut = (BallisticWeapon) ItemDB.lookup(1023);
 
         assertTrue(cut.getName().contains("LB 10-X AC"));
-        assertEquals(1, cut.getAmmoPerPerShot());
+        assertEquals(1, cut.getRoundsPerShot());
         assertEquals(10.0, cut.getDamagePerShot(), 0.0);
     }
 

--- a/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/BallisticWeaponTest.java
@@ -43,7 +43,7 @@ public class BallisticWeaponTest {
 
         assertTrue(cut.getName().contains("C-ULTRA AC/10"));
         assertEquals(3, cut.getRoundsPerShot());
-        assertEquals(10.0, cut.getDamagePerShot(), 0.0001);
+        assertEquals(10.0, cut.getDamagePerShot(), 0.0003);
 
         final double expectedSecondsPerShot = cut.getCoolDown(null); 
 

--- a/src/test/java/org/lisoft/lsml/model/item/MissileWeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/MissileWeaponTest.java
@@ -155,7 +155,7 @@ public class MissileWeaponTest {
     @Test
     public void testGetShotsPerVolley_lrm10() throws Exception {
         final Weapon lrm10 = (Weapon) ItemDB.lookup("LRM 10");
-        assertEquals(10, lrm10.getAmmoPerPerShot());
+        assertEquals(10, lrm10.getRoundsPerShot());
     }
 
     /**

--- a/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
@@ -65,7 +65,6 @@ public class WeaponTest {
         final Attribute aCooldown = new Attribute(cooldown, selectors, ModifierDescription.SPEC_WEAPON_COOL_DOWN);
 
         final int aRoundsPerShot = 15;
-        final int aVolleySize = 1;
         final double aDamagePerProjectile = 16;
         final int aProjectilesPerRound = 17;
         final int projectileSpeed = 36;
@@ -315,7 +314,7 @@ public class WeaponTest {
     }
     
     @Test
-    public void testCheckExpectedDamage() throws Exception {
+    public void testRawExpectedFiringPeriodAllWeapons() throws Exception {
         final List<Weapon> weapons = ItemDB.lookup(Weapon.class);
         double rFP, eFP;
         

--- a/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
@@ -316,11 +316,10 @@ public class WeaponTest {
     @Test
     public void testRawExpectedFiringPeriodAllWeapons() throws Exception {
         final List<Weapon> weapons = ItemDB.lookup(Weapon.class);
-        double rFP = 1.0, eFP = 1.0;
         
         for (Weapon weapon : weapons) {
-            rFP = weapon.getRawFiringPeriod(null);
-            eFP = weapon.getExpectedFiringPeriod(null);
+            double rFP = weapon.getRawFiringPeriod(null);
+            double eFP = weapon.getExpectedFiringPeriod(null);
             
             // jammming and multiple shots during cooldown are the two reasons that raw damage does not equal expected damage. 
             // both situations currently are only in ballistic weapons and the values are only available in the ballistic weapon class.

--- a/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
@@ -81,7 +81,7 @@ public class WeaponTest {
         final Weapon cut = new Weapon(aName, aDesc, aMwoName, aMwoId, aSlots, aTons, aHardPointType, aHP, aFaction,
                                       aHeat, aCooldown, aRangeProfile, aRoundsPerShot, aDamagePerProjectile,
                                       aProjectilesPerRound, aProjectileSpeed, aGhostHeatGroupId, aGhostHeatMultiplier,
-                                      aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
+                                      aGhostHeatMaxFreeAlpha, aImpulse);
 
         assertEquals(aName, cut.getName());
         assertEquals(aDesc, cut.getDescription());
@@ -108,7 +108,7 @@ public class WeaponTest {
         try {
             new Weapon(aName, aDesc, aMwoName, aMwoId, aSlots, aTons, aHardPointType, aHP, aFaction, aHeat, aCooldown,
                        aRangeProfile, 0, aDamagePerProjectile, aProjectilesPerRound, aProjectileSpeed,
-                       aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aVolleyDelay, aImpulse);
+                       aGhostHeatGroupId, aGhostHeatMultiplier, aGhostHeatMaxFreeAlpha, aImpulse);
             fail("Expected exception");
         } catch (final IllegalArgumentException e) {
             // Expected

--- a/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
@@ -316,7 +316,7 @@ public class WeaponTest {
     @Test
     public void testRawExpectedFiringPeriodAllWeapons() throws Exception {
         final List<Weapon> weapons = ItemDB.lookup(Weapon.class);
-        double rFP, eFP;
+        double rFP = 1.0, eFP = 1.0;
         
         for (Weapon weapon : weapons) {
             rFP = weapon.getRawFiringPeriod(null);

--- a/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/WeaponTest.java
@@ -323,7 +323,7 @@ public class WeaponTest {
             eFP = weapon.getExpectedFiringPeriod(null);
             
             // jammming and multiple shots during cooldown are the two reasons that raw damage does not equal expected damage. 
-            // both situations currently are only in ballistic weapons and teh values are only available in the ballistic weapon class.
+            // both situations currently are only in ballistic weapons and the values are only available in the ballistic weapon class.
             if (weapon instanceof BallisticWeapon) {
                 if (((BallisticWeapon)weapon).getJamProbability(null) != 0 || ((BallisticWeapon)weapon).getShotsDuringCooldown() != 0) {
                     // these should normally not be equal, but cannot gaurantee... so no test.


### PR DESCRIPTION
Adjusted eFP and rFP for ammo weapons.  Added reading the PGI files for volleysize and used that value where appropriate.  this now correctly calculates eFP and rFP for volley weapons (particularly missiles) and fixes issue #775.  And changed the name of the getAmmoPerPerShot to getRoundsPerShot which more exactly explains what it is doing.